### PR TITLE
Add notification service with RabbitMQ and PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.21-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o notificationservice ./cmd/api
+
+FROM alpine:3.18
+WORKDIR /app
+COPY --from=build /src/notificationservice ./notificationservice
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://localhost:8080/health || exit 1
+ENTRYPOINT ["./notificationservice"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# test
+# Notification Service
+
+Simple service storing notifications delivered via HTTP or RabbitMQ.
+
+## Running
+
+```
+docker-compose up --build
+```
+
+Service exposes:
+
+- `POST /notifications` to create a notification.
+- `GET /notifications` to list notifications with pagination and filtering.
+- `GET /health` health check used by container.
+
+RabbitMQ consumer listens on queue `notifications` with retry/backoff and dead-letter queue.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"notificationservice/internal/db"
+	"notificationservice/internal/model"
+	"notificationservice/internal/queue"
+)
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	ctx := context.Background()
+	store, err := db.New(ctx, getenv("DATABASE_URL", "postgres://postgres:postgres@db:5432/postgres?sslmode=disable"))
+	if err != nil {
+		log.Fatalf("db connect: %v", err)
+	}
+	defer store.Close()
+	if err := store.Migrate(ctx); err != nil {
+		log.Fatalf("db migrate: %v", err)
+	}
+
+	consumer, err := queue.NewConsumer(getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq:5672/"), store)
+	if err != nil {
+		log.Fatalf("rabbit connect: %v", err)
+	}
+	go consumer.Start(ctx)
+
+	router := gin.New()
+	router.Use(gin.Recovery())
+
+	router.POST("/notifications", func(c *gin.Context) {
+		var in model.NotificationInput
+		if err := c.BindJSON(&in); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+			return
+		}
+		if err := in.Validate(); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if err := store.CreateNotification(c.Request.Context(), in); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to store"})
+			return
+		}
+		log.Printf("stored notification from %s to %s", model.MaskEmail(in.Sender), model.MaskEmail(in.Recipient))
+		c.Status(http.StatusCreated)
+	})
+
+	router.GET("/notifications", func(c *gin.Context) {
+		var f db.ListFilter
+		if s := c.Query("sender"); s != "" {
+			f.Sender = &s
+		}
+		if r := c.Query("recipient"); r != "" {
+			f.Recipient = &r
+		}
+		if l := c.Query("limit"); l != "" {
+			if v, err := strconv.Atoi(l); err == nil {
+				f.Limit = v
+			}
+		}
+		if o := c.Query("offset"); o != "" {
+			if v, err := strconv.Atoi(o); err == nil {
+				f.Offset = v
+			}
+		}
+		list, err := store.ListNotifications(c.Request.Context(), f)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "query failed"})
+			return
+		}
+		c.JSON(http.StatusOK, list)
+	})
+
+	router.GET("/health", func(c *gin.Context) {
+		if err := store.Migrate(c.Request.Context()); err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	addr := getenv("ADDR", ":8080")
+	log.Printf("listening on %s", addr)
+	if err := router.Run(addr); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbit-data:/var/lib/rabbitmq
+  app:
+    build: .
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/postgres?sslmode=disable
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_started
+    ports:
+      - "8080:8080"
+volumes:
+  db-data:
+  rabbit-data:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module notificationservice
+
+go 1.21
+
+require (
+    github.com/gin-gonic/gin v1.9.1
+    github.com/jackc/pgx/v5 v5.4.3
+    github.com/rabbitmq/amqp091-go v1.8.0
+)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"notificationservice/internal/model"
+)
+
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+func New(ctx context.Context, dsn string) (*Store, error) {
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{pool: pool}, nil
+}
+
+func (s *Store) Close() {
+	s.pool.Close()
+}
+
+func (s *Store) Migrate(ctx context.Context) error {
+	_, err := s.pool.Exec(ctx, `CREATE TABLE IF NOT EXISTS notifications (
+        id SERIAL PRIMARY KEY,
+        sender TEXT NOT NULL,
+        recipient TEXT NOT NULL,
+        message TEXT NOT NULL,
+        hash TEXT UNIQUE NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )`)
+	return err
+}
+
+func hashNotification(n model.NotificationInput) string {
+	h := sha256.New()
+	h.Write([]byte(n.Sender))
+	h.Write([]byte{0})
+	h.Write([]byte(n.Recipient))
+	h.Write([]byte{0})
+	h.Write([]byte(n.Message))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (s *Store) CreateNotification(ctx context.Context, in model.NotificationInput) error {
+	hash := hashNotification(in)
+	_, err := s.pool.Exec(ctx, `INSERT INTO notifications (sender, recipient, message, hash) VALUES ($1,$2,$3,$4) ON CONFLICT (hash) DO NOTHING`,
+		in.Sender, in.Recipient, in.Message, hash)
+	return err
+}
+
+type ListFilter struct {
+	Sender    *string
+	Recipient *string
+	Limit     int
+	Offset    int
+}
+
+func (s *Store) ListNotifications(ctx context.Context, f ListFilter) ([]model.Notification, error) {
+	if f.Limit <= 0 || f.Limit > 100 {
+		f.Limit = 50
+	}
+	query := `SELECT id, sender, recipient, message, created_at FROM notifications`
+	var args []interface{}
+	var cond []string
+	if f.Sender != nil {
+		cond = append(cond, fmt.Sprintf("sender=$%d", len(args)+1))
+		args = append(args, *f.Sender)
+	}
+	if f.Recipient != nil {
+		cond = append(cond, fmt.Sprintf("recipient=$%d", len(args)+1))
+		args = append(args, *f.Recipient)
+	}
+	if len(cond) > 0 {
+		query += " WHERE " + strings.Join(cond, " AND ")
+	}
+	query += fmt.Sprintf(" ORDER BY id DESC LIMIT $%d OFFSET $%d", len(args)+1, len(args)+2)
+	args = append(args, f.Limit, f.Offset)
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []model.Notification
+	for rows.Next() {
+		var n model.Notification
+		if err := rows.Scan(&n.ID, &n.Sender, &n.Recipient, &n.Message, &n.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}

--- a/internal/model/notification.go
+++ b/internal/model/notification.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"errors"
+	"net/mail"
+	"strings"
+	"time"
+)
+
+type Notification struct {
+	ID        int64     `json:"id"`
+	Sender    string    `json:"sender"`
+	Recipient string    `json:"recipient"`
+	Message   string    `json:"message"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type NotificationInput struct {
+	Sender    string `json:"sender"`
+	Recipient string `json:"recipient"`
+	Message   string `json:"message"`
+}
+
+func (n NotificationInput) Validate() error {
+	if _, err := mail.ParseAddress(n.Sender); err != nil {
+		return errors.New("invalid sender email")
+	}
+	if _, err := mail.ParseAddress(n.Recipient); err != nil {
+		return errors.New("invalid recipient email")
+	}
+	if strings.TrimSpace(n.Message) == "" {
+		return errors.New("message required")
+	}
+	return nil
+}
+
+func MaskEmail(e string) string {
+	parts := strings.Split(e, "@")
+	if len(parts) != 2 {
+		return "***"
+	}
+	local := parts[0]
+	if len(local) > 2 {
+		local = local[:1] + "***" + local[len(local)-1:]
+	} else {
+		local = "***"
+	}
+	return local + "@" + parts[1]
+}

--- a/internal/queue/consumer.go
+++ b/internal/queue/consumer.go
@@ -1,0 +1,131 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/rabbitmq/amqp091-go"
+	"notificationservice/internal/db"
+	"notificationservice/internal/model"
+)
+
+const (
+	mainQueue  = "notifications"
+	retryQueue = "notifications.retry"
+	dlqQueue   = "notifications.dlq"
+	dlx        = "notifications.dlx"
+)
+
+type Consumer struct {
+	conn    *amqp.Connection
+	channel *amqp.Channel
+	store   *db.Store
+}
+
+func NewConsumer(url string, store *db.Store) (*Consumer, error) {
+	conn, err := amqp.Dial(url)
+	if err != nil {
+		return nil, err
+	}
+	ch, err := conn.Channel()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	c := &Consumer{conn: conn, channel: ch, store: store}
+	if err := c.setup(); err != nil {
+		ch.Close()
+		conn.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *Consumer) setup() error {
+	if err := c.channel.ExchangeDeclare(dlx, "direct", true, false, false, false, nil); err != nil {
+		return err
+	}
+	if _, err := c.channel.QueueDeclare(mainQueue, true, false, false, false, amqp.Table{
+		"x-dead-letter-exchange":    dlx,
+		"x-dead-letter-routing-key": retryQueue,
+	}); err != nil {
+		return err
+	}
+	if _, err := c.channel.QueueDeclare(retryQueue, true, false, false, false, amqp.Table{
+		"x-dead-letter-exchange":    "",
+		"x-dead-letter-routing-key": mainQueue,
+		"x-message-ttl":             int32(10000),
+	}); err != nil {
+		return err
+	}
+	if _, err := c.channel.QueueDeclare(dlqQueue, true, false, false, false, nil); err != nil {
+		return err
+	}
+	if err := c.channel.QueueBind(dlqQueue, dlqQueue, dlx, false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Consumer) Start(ctx context.Context) {
+	msgs, err := c.channel.Consume(mainQueue, "", false, false, false, false, nil)
+	if err != nil {
+		log.Printf("consume error: %v", err)
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case m := <-msgs:
+			c.handleMessage(m)
+		}
+	}
+}
+
+func (c *Consumer) handleMessage(m amqp.Delivery) {
+	var in model.NotificationInput
+	if err := json.Unmarshal(m.Body, &in); err != nil {
+		log.Printf("invalid message: %v", err)
+		m.Nack(false, false)
+		return
+	}
+	if err := in.Validate(); err != nil {
+		log.Printf("validation failed: %v", err)
+		m.Ack(false)
+		return
+	}
+	if err := c.store.CreateNotification(context.Background(), in); err != nil {
+		attempts := attemptCount(m)
+		if attempts >= 5 {
+			// send to DLQ
+			_ = c.channel.Publish("", dlqQueue, false, false, amqp.Publishing{Body: m.Body})
+			m.Ack(false)
+			return
+		}
+		m.Nack(false, false)
+		return
+	}
+	log.Printf("stored notification from %s to %s", model.MaskEmail(in.Sender), model.MaskEmail(in.Recipient))
+	m.Ack(false)
+}
+
+func attemptCount(m amqp.Delivery) int {
+	v, ok := m.Headers["x-death"]
+	if !ok {
+		return 0
+	}
+	deaths, ok := v.([]interface{})
+	if !ok || len(deaths) == 0 {
+		return 0
+	}
+	table, ok := deaths[0].(amqp.Table)
+	if !ok {
+		return 0
+	}
+	if cnt, ok := table["count"].(int64); ok {
+		return int(cnt)
+	}
+	return 0
+}


### PR DESCRIPTION
## Summary
- add HTTP API for notifications with health check
- store notifications with idempotent hash and email validation
- RabbitMQ consumer with retry and dead-letter queue
- docker-compose including Postgres and RabbitMQ with volumes and healthchecks

## Testing
- `go mod tidy` *(fails: Get https://goproxy.io/...: Forbidden)*
- `go build ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_b_68babea99edc833091880029479f9e39